### PR TITLE
Feature: Validate response

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "tsc --project ./tsconfig.build.json",
     "postbuild": "mkdir build/template/ && cp src/template/express.ts.hbs build/template/express.ts.hbs",
     "test": "NODE_V8_COVERAGE=./coverage ava",
-    "posttest": "c8 --all report -x example -x build -x src/types.ts -x tests -x src/runtime/decorators.ts -x node_modules --temp-directory=./coverage/ --report-dir=./coverage -r json"
+    "posttest": "c8 --all report -x example -x build -x src/types.ts -x tests -x src/runtime/decorators.ts -x node_modules --temp-directory=./coverage/ --report-dir=./coverage -r json",
+    "lint": "tslint --fix --project ."
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -67,7 +67,9 @@ export function addController (
       } else {
         operation.responses![httpCode] = { description: description ?? '' }
       }
-      if (parseInt(httpCode, 10) >= 200 && parseInt(httpCode, 10) <= 299) hasSuccessResponse = true
+      if (parseInt(httpCode, 10) >= 200 && parseInt(httpCode, 10) <= 299) {
+        hasSuccessResponse = true
+      }
     }
 
     // Add default success response

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,12 @@ export type OpenAPIConfiguration = {
      * You must export a variable/function named `securityMiddleware`
      */
     securityMiddlewarePath?: string
+
+    /**
+     * If `true`, the result will be validated against the schema
+     * and any extra properties will be removed.
+     */
+    validateResponse?: boolean;
   }
 }
 
@@ -127,7 +133,7 @@ export async function generate (config: OpenAPIConfiguration) {
       for (const controller of controllers) {
         const routeDecorator = controller.getDecorator('Route')
         if (routeDecorator === undefined) continue // skip
-        addController(controller, spec, codegenControllers)
+        addController(controller, spec, codegenControllers, config.router)
         controllersPathByName[controller.getName()!] = filePath
       }
     }
@@ -242,7 +248,7 @@ export async function generate (config: OpenAPIConfiguration) {
     securityMiddleware: config.router.securityMiddlewarePath ? getRelativeFilePath(
       path.dirname(routerFilePath),
       path.resolve(root, config.router.securityMiddlewarePath)
-     ) : undefined,
+    ) : undefined,
     controllers: Object.keys(codegenControllers).map((controllerName) => {
       return {
         name: controllerName,

--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -157,7 +157,7 @@ function validateAndParseValueAgainstSchema (
   // Strings
   if (currentSchema.type === 'string') {
     if (value instanceof Date && currentSchema.format === 'date-time') {
-      value = value.toISOString()
+      return value
     }
     if (typeof value !== 'string') {
       throw new ValidateError({

--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -71,6 +71,34 @@ export async function validateAndParse (
   return args
 }
 
+export function validateAndParseResponse (
+  data: unknown,
+  schemas: OpenAPIV3.ComponentsObject['schemas'],
+  rules: Record<string, OpenAPIV3.ResponseObject>,
+  statusCode: string,
+  contentType: string
+): unknown {
+  try {
+    const rule = rules[statusCode] ?? rules.default
+    if (!rule) throw new ValidateError({ response: { message: `Missing response schema for status code ${statusCode}` } }, 'Invalid status code')
+    const expectedSchema = rule.content?.[contentType]?.schema
+    if (typeof expectedSchema === 'undefined') {
+      if (typeof data === 'undefined' || data === null) {
+        return data
+      }
+      log(`Schema is not found for '${contentType}', throwing error`)
+      throw new ValidateError({}, 'This content-type is not allowed')
+    }
+    return validateAndParseValueAgainstSchema('response', data, expectedSchema, schemas)
+  } catch (e) {
+    if (e instanceof ValidateError) {
+      // validation error on the result is a server, not client error
+      e.status = 500
+    }
+    throw e
+  }
+}
+
 async function validateBody (
   req: express.Request,
   rule: OpenAPIV3.RequestBodyObject,
@@ -128,6 +156,9 @@ function validateAndParseValueAgainstSchema (
   }
   // Strings
   if (currentSchema.type === 'string') {
+    if (value instanceof Date && currentSchema.format === 'date-time') {
+      value = value.toISOString()
+    }
     if (typeof value !== 'string') {
       throw new ValidateError({
         [name]: { message: 'This property must be a string', value }

--- a/src/template/express.ts.hbs
+++ b/src/template/express.ts.hbs
@@ -33,7 +33,17 @@ export function bindToRouter (router: express.Router) {
           }
         ) as any
       )
+      {{#if validateResponse}}
+      const validatedData = Validator.validateAndParseResponse(
+        data, schemas as any, 
+        {{json responses}},
+        ('getStatus' in controller ? (controller as any).getStatus()?.toString() : undefined) ?? (typeof data !== 'undefined' && data !== null ? '200' : '204'),
+        ((('getHeaders' in controller ? (controller as any).getHeaders()?.['content-type'] : undefined) ?? 'application/json')).split(';')[0]
+      )
+      RuntimeResponse.send(controller, validatedData, res)
+      {{else}}
       RuntimeResponse.send(controller, data, res)
+      {{/if}}
     } catch (err) {
       return next(err)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,5 +10,7 @@ export type CodeGenControllers = Record<string, {
   bodyDiscriminator?: {
     path: string,
     name: string
-  }
+  },
+  responses: OpenAPIV3.OperationObject['responses'],
+  validateResponse: boolean
 }[]>

--- a/tests/fixture/router-controller.ts
+++ b/tests/fixture/router-controller.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { Controller, Route, Get, Post, Header, Body, Request, Query, Delete, Path, Patch, BodyDiscriminatorFunction, Security, Hidden } from '../../src'
+import { Controller, Route, Get, Post, Header, Body, Request, Query, Delete, Path, Patch, BodyDiscriminatorFunction, Security, Hidden, Response } from '../../src'
 
 enum EnumString {
   FOO = 'foo',
@@ -33,6 +33,7 @@ export class MyController extends Controller {
   }
 
   @Post()
+  @Response<ReturnType<MyController['post']>>(201)
   public async post (
     @Header('x-custom-header') header: string,
     @Body() body: {
@@ -118,6 +119,13 @@ export class MyController extends Controller {
     }
   ) {
     return 'ok'
+  }
+
+  @Get('/getExtra')
+  public getExtra (
+  ): { foo: number } {
+    const data = { foo: 1, extra: 42 }
+    return data
   }
 }
 

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -30,7 +30,8 @@ test.before(async (t) => {
     },
     router: {
       filePath: tmpFile,
-      securityMiddlewarePath: path.resolve(__dirname, './fixture/security-middleware.ts')
+      securityMiddlewarePath: path.resolve(__dirname, './fixture/security-middleware.ts'),
+      validateResponse: true
     }
   })
   const routerContent = (await fs.promises.readFile(tmpFile)).toString()
@@ -533,4 +534,12 @@ test('Should not validate body with file', async (t) => {
   })
   t.is(res.status, 200)
   t.is(res.data, 'ok')
+})
+
+test('Should remove extra props from response', async (t) => {
+  const res = await api.get('/getExtra')
+  t.is(res.status, 200)
+  t.deepEqual(res.data, {
+    foo: 1
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/Eywek/typoa/issues/10

Adds a feature flag 'validateResponse' to the router config that has to be explicitly enabled.

While working on the feature, I discovered a few tiny glitches that made the validation fail, so these are also fixed here.