### PR TITLE
feat!: support multiple output formats & simplify configuration output

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ await generate({
   tsconfigFilePath: path.resolve(__dirname, './tsconfig.json'),
   controllers: [path.resolve(__dirname, './*.ts')], // Path of your controllers
   openapi: {
-    filePath: '/tmp/openapi.json', // Where do you want to generate your openapi file
-    format: 'json', // 'json' | 'yaml'
+    // Where do you want to generate your openapi file (or array of file paths)
+    // The file extension (.json, .yaml, or .yml) determines the output format
+    filePath: '/tmp/openapi.json',
     service: { // Used in the openapi definitions
       name: 'my-service',
       version: '1.0.0'

--- a/tests/openapi-additional-types.test.ts
+++ b/tests/openapi-additional-types.test.ts
@@ -7,7 +7,6 @@ const config = {
   controllers: [],
   openapi: {
     filePath: '/tmp/openapi.json',
-    format: 'json' as const,
     service: {
       name: 'my-service',
       version: '1.0.0'

--- a/tests/router-discriminator.test.ts
+++ b/tests/router-discriminator.test.ts
@@ -6,7 +6,6 @@ const config = {
   tsconfigFilePath: path.resolve(__dirname, './fixture/tsconfig.json'),
   openapi: {
     filePath: '/tmp/openapi.json',
-    format: 'json' as const,
     service: {
       name: 'my-service',
       version: '1.0.0'

--- a/tests/router-middleware.test.ts
+++ b/tests/router-middleware.test.ts
@@ -6,7 +6,6 @@ const config = {
   tsconfigFilePath: path.resolve(__dirname, './fixture/tsconfig.json'),
   openapi: {
     filePath: '/tmp/openapi.json',
-    format: 'json' as const,
     service: {
       name: 'my-service',
       version: '1.0.0'

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -22,7 +22,6 @@ test.before(async (t) => {
     ],
     openapi: {
       filePath: '/tmp/openapi.json',
-      format: 'json',
       service: {
         name: 'my-service',
         version: '1.0.0'


### PR DESCRIPTION
I tried to make setting the output type easier, so now you can define multiple outputs in one step. Instead of using separate `filePath` and `format` options, there's just one `filePath` string/structure that describes how many files to create and in which format.

But this is a breaking change, so I'm not sure if it's really useful or something people want.