### PR TITLE
fix: prevent infinite loop in Omit<Class, 'toJSON'> resolution

### DIFF
--- a/tests/fixtures/controllers/controller-infinite-loop-trigger.ts
+++ b/tests/fixtures/controllers/controller-infinite-loop-trigger.ts
@@ -1,0 +1,38 @@
+import { Get, Post, Body, Route } from '../../../src'
+
+// Using Omit<Foo, 'toJSON'> creates circular dependency during type resolution:
+// 1. Omit<Foo, 'toJSON'> tries to resolve Foo properties
+// 2. When resolving Foo.toJSON method, it encounters return type Omit<Foo, 'toJSON'>
+// 3. This creates circular dependency: Omit<Foo, 'toJSON'> → Foo → Omit<Foo, 'toJSON'> → ∞
+// The mapped type resolver gets stuck in infinite recursion
+
+class Foo {
+  public foo: string = 'default'
+
+  public toJSON(): Omit<Foo, 'toJSON'> {
+    return { 'foo': 'bar' }
+  }
+}
+
+@Route('infinite-loop-trigger')
+export class InfiniteLoopTriggerController {
+  @Get()
+  public getSerializedFoo(): Omit<Foo, 'toJSON'> {
+    return { foo: 'bar' }
+  }
+
+  @Post()
+  public createFoo(@Body() data: Omit<Foo, 'toJSON'>): Foo {
+    const foo = new Foo()
+    foo.foo = data.foo
+    return foo
+  }
+
+  @Get('both')
+  public getBoth(): { serialized: Omit<Foo, 'toJSON'>, foo: Foo } {
+    return {
+      serialized: { foo: 'bar' },
+      foo: new Foo()
+    }
+  }
+}

--- a/tests/unit/circular-tojson.test.ts
+++ b/tests/unit/circular-tojson.test.ts
@@ -1,0 +1,59 @@
+import path from 'path';
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { generate } from '../../src';
+
+test('Should handle Omit<Class, "toJSON"> with circular toJSON correctly', async () => {
+  const openapiFile = path.resolve(__dirname, 'generated-openapi-circular-tojson-test.json');
+  const routerFile = path.resolve(__dirname, 'generated-router-circular-tojson.ts');
+
+  await generate({
+    tsconfigFilePath: path.resolve(__dirname, '../fixtures/tsconfig.json'),
+    controllers: [path.resolve(__dirname, '../fixtures/controllers/controller-infinite-loop-trigger.ts')],
+    openapi: {
+      filePath: openapiFile,
+      service: {
+        name: 'circular-tojson-test',
+        version: '1.0.0'
+      }
+    },
+    router: {
+      filePath: routerFile
+    }
+  });
+
+  const spec = (await import(openapiFile)).default;
+
+  // Verify that generation completed without infinite loop
+  assert.ok(spec);
+  assert.ok(spec.components);
+  assert.ok(spec.components.schemas);
+  
+  // Verify the controller paths were generated
+  assert.ok(spec.paths);
+  assert.ok(spec.paths['/infinite-loop-trigger']);
+  assert.ok(spec.paths['/infinite-loop-trigger'].get);
+  assert.ok(spec.paths['/infinite-loop-trigger'].post);
+  
+  // Verify that Foo schema was generated (should reference Foo_Without_ToJSON to break circular reference)
+  const fooSchema = spec.components.schemas.Foo;
+  assert.ok(fooSchema);
+  assert.strictEqual(fooSchema.$ref, '#/components/schemas/Foo_Without_ToJSON');
+  
+  // Verify that Omit schemas were generated with proper names and structure
+  const omitSchema = spec.components.schemas['Foo_Without_ToJSON'];
+  assert.ok(omitSchema);
+  assert.strictEqual(omitSchema.type, 'object');
+  assert.ok(omitSchema.properties);
+  assert.ok(omitSchema.properties.foo);
+  assert.strictEqual(omitSchema.properties.foo.type, 'string');
+  
+  // Verify the response schema references are correct
+  const getResponse = spec.paths['/infinite-loop-trigger'].get.responses['200'];
+  assert.ok(getResponse);
+  assert.ok(getResponse.content);
+  assert.ok(getResponse.content['application/json']);
+  assert.ok(getResponse.content['application/json'].schema);
+  assert.strictEqual(getResponse.content['application/json'].schema.$ref, '#/components/schemas/Foo_Without_ToJSON');
+});


### PR DESCRIPTION
Skip toJSON method when explicitly omitted to break circular reference
that caused stack overflow during OpenAPI schema generation.

Fixes regression from https://github.com/Eywek/typoa/pull/28