### PR TITLE
fix: handle empty arrays with 'never' element type in resolve function

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -77,9 +77,17 @@ export function resolve (
   }
   // Handle types
   if (type.isArray()) {
+    const elementType = type.getArrayElementTypeOrThrow()
+    // Handle empty arrays where element type is 'never'
+    if (elementType.getText() === 'never') {
+      return {
+        type: 'array',
+        items: {}
+      }
+    }
     return {
       type: 'array',
-      items: resolve(type.getArrayElementTypeOrThrow(), spec)
+      items: resolve(elementType, spec)
     }
   }
   if (type.isBoolean()) {


### PR DESCRIPTION
Fixes an issue where controllers returning arrays were incorrectly typed as `any[]` / `never[]` in the generated schema.

```ts
@Get("/foo")
async getHealth(@Request() req: express.Request) {
    return {
        status: "UP",
        checks: [],
    };
}
```

Before (generated schema):

``` yaml
/foo:
    get:
        parameters: []
        responses:
            '200':
                description: Ok
                content:
                    application/json:
                        schema:
                            type: object
                            properties:
                                foo: {type: array, items: {type: never}}
                            required:
                                - status
```

After (expected schema):

```yaml
/foo:
    get:
        parameters: []
        responses:
            '200':
                description: Ok
                content:
                    application/json:
                        schema:
                            type: object
                            properties:
                                status: {type: string}
                                checks: {type: array, items: {type: object}}
                            required:
                                - status
```