### PR TITLE
feat: downgrade log level when body can't be parsed

### DIFF
--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -188,9 +188,7 @@ async function validateBody(
   logger: CustomLogger
 ): Promise<unknown> {
   const body = req.body
-  const contentType = (req.headers['content-type'] ?? 'application/json').split(
-    ';'
-  )[0]
+  const contentType = (req.headers['content-type'] ?? 'application/json').split(';')[0]
 
   const expectedSchema = rule.content[contentType]?.schema
   if (typeof expectedSchema === 'undefined') {
@@ -199,7 +197,7 @@ async function validateBody(
   }
 
   if (req.readableEnded === false) {
-    logger.debug(`! Warning: Body has not be parsed, body validation skipped !`)
+    logger.debug(`Body has not be parsed, body validation skipped!`)
     return body
   }
 

--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -191,15 +191,18 @@ async function validateBody(
   const contentType = (req.headers['content-type'] ?? 'application/json').split(
     ';'
   )[0]
+
   const expectedSchema = rule.content[contentType]?.schema
   if (typeof expectedSchema === 'undefined') {
     logger.error(`Schema is not found for '${contentType}', throwing error`)
     throw new ValidateError({}, 'This content-type is not allowed')
   }
+
   if (req.readableEnded === false) {
-    logger.warn(`! Warning: Body has not be parsed, body validation skipped !`)
+    logger.debug(`! Warning: Body has not be parsed, body validation skipped !`)
     return body
   }
+
   if (discriminatorFn) {
     const schemaName = await discriminatorFn(req)
     const validationResult = validateAndParseValueAgainstSchema(


### PR DESCRIPTION
With the introduction of the provided logger, this log is thrown massiverly.
 
 Compared to others warn log thrown by Typoa, this log is not interesting and does not deserve `WARN` level.
 Debug level would be enough